### PR TITLE
Allowing Turbo Distances for Julia 1.11

### DIFF
--- a/src/distances/Distances.jl
+++ b/src/distances/Distances.jl
@@ -9,7 +9,7 @@
     include("cos.jl")
     include("cloud.jl")
     include("hacks.jl")
-    @static if VERSION < v"1.11"
+    @static if VERSION < v"1.12"
         include("turboed.jl")
     end
 #end


### PR DESCRIPTION
LoopVectorization.jl is working on Julia 1.11 but right now it has warnings for Julia 1.12

Julia 1.11 has been released so this restriction needs to be replaced